### PR TITLE
initial attempt at slice

### DIFF
--- a/src/NumHask/Tensor.hs
+++ b/src/NumHask/Tensor.hs
@@ -36,6 +36,7 @@ import NumHask.Algebra.Multiplicative
 import Test.QuickCheck
 import qualified Data.Vector as V
 import NumHask.Naperian
+import Data.List ((!!))
 
 -- | an n-dimensional array where shape is specified at the type level
 -- The main purpose of this, beyond safe typing, is to supply the Representable instance with an initial object.
@@ -181,3 +182,17 @@ instance forall a. (Arbitrary a, AdditiveUnital a) => Arbitrary (SomeTensor a) w
         [ (1, P.pure (SomeTensor [] V.empty))
         , (9, fromListSomeTensor <$> (unshapeT <$> arbitrary) P.<*> vector 48)
         ]
+
+slice :: forall a r s. (SingI r, SingI s) =>
+    [[Int]] -> Tensor (r::[Nat]) a -> Tensor (s::[Nat]) a
+slice xs f = tabulate $ \xs' -> index f (zipWith (!!) xs xs')
+
+{-
+slice' :: forall a r s. (SingI r) =>
+    [[Int]] -> Tensor (r::[Nat]) a -> Tensor (s::[Nat]) a
+slice' xs f = case ss of
+  SomeSing s' -> (tabulate $ \xs' -> index f (zipWith (!!) xs xs')) :: Tensor s' a
+  where
+    ss :: SomeSing [Nat]
+    ss = toSing $ P.fromIntegral . P.length <$> xs
+-}


### PR DESCRIPTION
Holding shape at type level works very well until you get to trying to change shape.  In this attempt, I've defined a function `slice` which is essential for n-dimensional array manipulation.  It works as long as the coder keeps track of the actual type:

~~~
>>> :set -XDataKinds
>>> :set -XOverloadedLIsts
>>> let a = [1..24] :: Tensor '[2,3,4]
>>> a
[[[1, 2, 3, 4],
  [5, 6, 7, 8],
  [9, 10, 11, 12]],
 [[13, 14, 15, 16],
  [17, 18, 19, 20],
  [21, 22, 23, 24]]]
>>>  slice [[0,1],[2],[1,2]] a :: Tensor '[2,1,2] Int
[[[6, 7]],
 [[12, 13]]]
~~~

but how do you allow the type system to work this out for you?
