### PR TITLE
remove DatatypeContexts, no GADTs

### DIFF
--- a/numhask-array/src/NumHask/Array.hs
+++ b/numhask-array/src/NumHask/Array.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 module NumHask.Array where
 
 import Data.Distributive

--- a/numhask-prelude/numhask-prelude.cabal
+++ b/numhask-prelude/numhask-prelude.cabal
@@ -39,6 +39,7 @@ library
     , tasty-quickcheck >= 0.9.2 && <1.0
   exposed-modules:
       NumHask.Prelude
+      NumHask.Error
       NumHask.Examples
       NumHask.Laws
   other-modules:

--- a/numhask-prelude/src/NumHask/Error.hs
+++ b/numhask-prelude/src/NumHask/Error.hs
@@ -2,7 +2,7 @@
 module NumHask.Error where
 
 import Protolude
-import Protolude.Error (error)
+import Protolude.Panic (panic)
 
-impossible :: Text -> a
-impossible msg = error ("[impossible]" <> msg)
+impossible :: HasCallStack => Text -> a
+impossible = panic

--- a/numhask-prelude/src/NumHask/Error.hs
+++ b/numhask-prelude/src/NumHask/Error.hs
@@ -1,0 +1,8 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+module NumHask.Error where
+
+import Protolude
+import Protolude.Error (error)
+
+impossible :: Text -> a
+impossible msg = error ("[impossible]" <> msg)


### PR DESCRIPTION
DatatypeContexts is removed from the latest GHC which caused numhask-array to break on my box. (see: https://stackoverflow.com/questions/7438600/datatypecontexts-deprecated-in-latest-ghc-why#7438716).

I've been working a bit with Dimensions and, from what I can tell, enforcing `(ds::[Nat])` should be enough for Array. Alternatively, you could use GADTs (as cited in the SO answer), but that seems like overkill for something that is already functioning perfectly fine.

I also cleaned some of the warnings:
- `-Wredundant-constraints`: the `Dimensions '[m, n]` constraint [implies that `m` and `n` are Nats](https://hackage.haskell.org/package/dimensions-0.3.2.0/docs/Numeric-Dimensions-Dim.html#t:Dimensions), which has been true [since dimensions-0.1.0.0](https://hackage.haskell.org/package/dimensions-0.1.0.0/docs/Numeric-Dimensions-Dim.html#t:Dimensions) so this should be backward-compatible.
- `-fwarn-incomplete-patterns`: I've introduced a `NumHask.Prelude.Error.impossible` function to appease GHC in this kind of situation.