### PR TITLE
Introduce `hunit-numhask`

### DIFF
--- a/hunit-numhask/.gitignore
+++ b/hunit-numhask/.gitignore
@@ -1,0 +1,4 @@
+/dist/
+/.cabal-sandbox/
+/cabal.sandbox.config
+/.stack-work/

--- a/hunit-numhask/.travis.yml
+++ b/hunit-numhask/.travis.yml
@@ -1,0 +1,34 @@
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+# The different configurations we want to test. You could also do things like
+# change flags or use --stack-yaml to point to a different file.
+env:
+- ARGS=""
+- ARGS="--resolver lts"
+- ARGS="--resolver nightly-2018-04-04"
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
+script: stack $ARGS --no-terminal --install-ghc test --haddock
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack

--- a/hunit-numhask/LICENSE
+++ b/hunit-numhask/LICENSE
@@ -1,0 +1,30 @@
+Copyright Marco Zocca (c) 2018
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Marco Zocca nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/hunit-numhask/README.md
+++ b/hunit-numhask/README.md
@@ -1,0 +1,5 @@
+# hunit-numhask
+
+[![Build Status](https://travis-ci.org/githubuser/hunit-numhask.png)](https://travis-ci.org/githubuser/hunit-numhask)
+
+TODO Description.

--- a/hunit-numhask/Setup.hs
+++ b/hunit-numhask/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/hunit-numhask/hunit-numhask.cabal
+++ b/hunit-numhask/hunit-numhask.cabal
@@ -1,0 +1,40 @@
+name:                hunit-numhask
+version:             0.1.0.0
+-- synopsis:
+-- description:
+homepage:            https://github.com/tonyday567/hunit-numhask
+license:             BSD3
+license-file:        LICENSE
+author:              Marco Zocca
+maintainer:          zocca.marco gmail
+copyright:           2018 Marco Zocca
+category:            Test
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+tested-with:         GHC == 8.4.1
+
+library
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  hs-source-dirs:      src
+  exposed-modules:     Test.HUnit.NumHask
+  build-depends:       base >= 4.7 && < 5
+                     , exceptions
+                     , HUnit
+                     , numhask
+
+test-suite spec
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , hunit-numhask
+                     , hspec
+                     , QuickCheck
+
+source-repository head
+  type:     git
+  location: https://github.com/githubuser/hunit-numhask

--- a/hunit-numhask/src/Test/HUnit/NumHask.hs
+++ b/hunit-numhask/src/Test/HUnit/NumHask.hs
@@ -1,6 +1,8 @@
 {-# language DeriveDataTypeable #-}
 module Test.HUnit.NumHask (
+  -- * HUnit combinators
     shouldBeAbout
+    -- * Exceptions
   , FPE(..)
   ) where
 

--- a/hunit-numhask/src/Test/HUnit/NumHask.hs
+++ b/hunit-numhask/src/Test/HUnit/NumHask.hs
@@ -1,0 +1,36 @@
+{-# language DeriveDataTypeable #-}
+module Test.HUnit.NumHask (
+    shouldBeAbout
+  , FPE(..)
+  ) where
+
+import Control.Monad (unless)
+import Control.Exception (Exception(..))
+import Data.Typeable
+import Control.Monad.Catch (MonadThrow(..), throwM)
+
+import Test.HUnit
+
+import Prelude hiding (Num(..), (/))
+import NumHask.Algebra
+
+
+-- | A notion of approximate equality that takes into account floating point precision
+--
+-- > shouldBeAbout (1/3 :: Float) (0.333333)
+-- >
+--
+-- > shouldBeAbout (1/3 :: Float) (0.33333)
+-- > *** Exception: NotAboutEqual "expected: 0.33333\n but got: 0.33333334"
+shouldBeAbout :: (Show a, Epsilon a) => a -> a -> Assertion
+shouldBeAbout actual expected = 
+  unless (actual `aboutEqual` expected) $
+    throwM $ NotAboutEqual ("expected: " ++ show expected ++ "\n but got: " ++ show actual)
+
+
+
+
+-- | Floating point exceptions
+data FPE = NotAboutEqual String -- ^ Failure of the @Epsilon@ approximate equality test ('aboutEqual')
+  deriving (Eq, Show, Typeable)
+instance Exception FPE

--- a/hunit-numhask/stack.yaml
+++ b/hunit-numhask/stack.yaml
@@ -1,0 +1,11 @@
+resolver: nightly-2018-04-04
+
+packages:
+- .
+
+extra-deps: 
+- numhask-0.2.0.0
+
+# Override default flag values for local packages and extra-deps
+# flags: {}
+

--- a/hunit-numhask/test/LibSpec.hs
+++ b/hunit-numhask/test/LibSpec.hs
@@ -1,0 +1,17 @@
+module LibSpec where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+
+import Lib (ourAdd)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "Lib" $ do
+    it "works" $ do
+      True `shouldBe` True
+    prop "ourAdd is commutative" $ \x y ->
+      ourAdd x y `shouldBe` ourAdd y x

--- a/hunit-numhask/test/LibSpec.hs
+++ b/hunit-numhask/test/LibSpec.hs
@@ -1,17 +1,16 @@
 module LibSpec where
 
 import Test.Hspec
-import Test.Hspec.QuickCheck
 
-import Lib (ourAdd)
+import Test.HUnit.NumHask (shouldBeAbout)
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
 spec =
-  describe "Lib" $ do
-    it "works" $ do
-      True `shouldBe` True
-    prop "ourAdd is commutative" $ \x y ->
-      ourAdd x y `shouldBe` ourAdd y x
+  describe "Test.HUnit.NumHask" $ do
+    it "Tests Float values for approximate equality" $ 
+      (1/3 :: Float) `shouldBeAbout` 0.333333
+    it "Tests Double values for approximate equality" $ 
+      (1/3 :: Double) `shouldBeAbout` 0.333333333333

--- a/hunit-numhask/test/Spec.hs
+++ b/hunit-numhask/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
A binding library for Hunit that introduces Epsilon-based floating point comparison