### PR TITLE
Fixed wrong behaviour in Rational

### DIFF
--- a/numhask-test/src/NumHask/Laws.hs
+++ b/numhask-test/src/NumHask/Laws.hs
@@ -378,14 +378,24 @@ quotientFieldLaws :: (Field a, QuotientField a Integer, FromInteger a) => [Law2 
 quotientFieldLaws =
   [ ( "a - one < floor a <= a <= ceiling a < a + one"
     , Unary10
-        (\a ->
-           ((a - one) < (fromInteger (floor a))) &&
-           (fromInteger (floor a) <= a) &&
-           (a <= fromInteger (ceiling a)) &&
-           (fromInteger (ceiling a) < a + one)))
+      (\a ->
+        ((a - one) < (fromInteger (floor a)))
+          && (fromInteger (floor a) <= a)
+          && (a <= fromInteger (ceiling a))
+          && (fromInteger (ceiling a) < a + one)
+      )
+    )
   , ( "round a == floor (a + one/(one+one))"
-    , Unary10 (\a -> (round a :: Integer) == ((floor (a + one / (one + one))))))
-  ]
+    , Unary10
+      (\a -> case even ((floor $ a + one / (one + one)) :: Integer) of
+        True  -> ((round a :: Integer) == (floor $ a + (one / (one + one))))
+        False -> ((round a :: Integer) == (ceiling $ a - (one / (one + one))))
+      )
+    )
+  ] where
+    sign' a
+      | (floor a :: Integer) < 0 = -1
+      | otherwise = 1
 
 expFieldLaws :: forall a b.
      (FromInteger b, AdditiveUnital b, ExpField a, Normed a b, Epsilon a, Ord a, Ord b) => [Law2 a b]

--- a/numhask-test/test/test.hs
+++ b/numhask-test/test/test.hs
@@ -319,13 +319,10 @@ testsRational =
     , testGroup "Rational" $ testLawOf ([] :: [Rational]) <$> rationalLaws
 
     -- fixme: rounding and infinities need work
-{-
-    , testGroup "Quotient Field" $
-      testLawOf ([] :: [Rational]) <$> quotientFieldLaws
-    , testGroup "Upper Bounded Field" $
-      testLawOf ([] :: [Rational]) <$> upperBoundedFieldLaws
-    , testGroup "Lower Bounded Field" $
-      testLawOf ([] :: [Rational]) <$> lowerBoundedFieldLaws
 
--}
+    , testGroup "Quotient Field" $ testLawOf2 ([] :: [(Rational, Integer)]) <$> quotientFieldLaws
+    , testGroup "Upper Bounded Field" $ testLawOf ([] :: [Rational]) <$> upperBoundedFieldLaws
+    , testGroup "Lower Bounded Field" $ testLawOf ([] :: [Rational]) <$> lowerBoundedFieldLaws
+
+
     ]

--- a/numhask/src/NumHask/Algebra/Field.hs
+++ b/numhask/src/NumHask/Algebra/Field.hs
@@ -130,7 +130,7 @@ class (P.Ord a, Field a, P.Eq b, Integral b, AdditiveGroup b, MultiplicativeUnit
       in
         case P.compare half_down zero of
           P.LT -> n
-          P.EQ -> bool n m (even n)
+          P.EQ -> bool m n (even n)
           P.GT -> m
 
   ceiling :: a -> b

--- a/numhask/src/NumHask/Algebra/Field.hs
+++ b/numhask/src/NumHask/Algebra/Field.hs
@@ -130,7 +130,7 @@ class (P.Ord a, Field a, P.Eq b, Integral b, AdditiveGroup b, MultiplicativeUnit
       in
         case P.compare half_down zero of
           P.LT -> n
-          P.EQ -> bool m n (even n)
+          P.EQ -> bool n m (even n)
           P.GT -> m
 
   ceiling :: a -> b


### PR DESCRIPTION
This pull request addresses #51.
Took surprisingly long to find the culprits.

I think I fixed the round-breakage, but the tests are failing. The funny thing is that I can't reproduce it in ghci. I will look at it again tomorrow, maybe I am too tired.