### PR TITLE
Update Array NFData instance

### DIFF
--- a/numhask-array/src/NumHask/Array.hs
+++ b/numhask-array/src/NumHask/Array.hs
@@ -54,15 +54,15 @@ newtype instance
     Array { _getContainer :: c t}
     deriving (Functor, Foldable)
 
-instance NFData (Array c ds t) where
-  rnf a = seq a ()
+instance NFData (c t) => NFData (Array c (ds :: [Nat]) t) where
+  rnf (Array a) = rnf a
 
 {-
 -- | instance of array where some of the dimensions are known at compile time
 -- it wraps an Array with some weird magic
 data instance Array c (xds :: [XNat]) t = forall (ds :: [Nat]).
   ( FixedDims xds ds
-  , Dimensions ds) =>
+  , Dimensions ds) =>` 
   SomeArray (Array c ds t)
 
 -}


### PR DESCRIPTION
Using `rnf`instead of `seq` to fully evaluate the underlying data to normal form, instead of whnf.

The benchmarks from `fastest-matrices` make much more sense! We observe a x2 factor between simple multiplication and the "repeated multiplication" operation, which is about the same factor as DLA, and hmatrix.