### PR TITLE
Reverts cabal-version to 2.4

### DIFF
--- a/numhask-hedgehog/numhask-hedgehog.cabal
+++ b/numhask-hedgehog/numhask-hedgehog.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 2.4
 name: numhask-hedgehog
 version: 0.4.0
 synopsis:

--- a/numhask-prelude/numhask-prelude.cabal
+++ b/numhask-prelude/numhask-prelude.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 2.4
 name: numhask-prelude
 version: 0.5.0
 synopsis:

--- a/numhask/numhask.cabal
+++ b/numhask/numhask.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 2.4
 name: numhask
 version: 0.5.0
 synopsis:


### PR DESCRIPTION
Closes #141 by reverting the `cabal-version` field the `*.cabal` files associated with the various `numhask` projects.

Since none of these files were using any of the features that came with `cabal-version: 3.0`, all that needs to be changed is this field.

Unfortunately, I don't think Hackage metadata revisions allow the `cabal-version` field to be modified like this; if you'd like to make this change, then the library would need a patch version bump (e.g. `numhask-0.5.1`).