### PR TITLE
Revert operator migration

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -78,4 +78,4 @@ jobs:
           stack build --test --no-install-ghc --system-ghc
       - if: matrix.docspec
         name: run cabal-docspec
-        run: cabal-docspec
+        run: cabal-docspec --check-properties

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+0.10.0
+===
+* Moved operators back in.
+* added doctests and properties
+* added accsum & accproduct
+* fixed Ratio Eq instance
+
 0.9.0
 ===
 * Removed bounded classes.

--- a/numhask.cabal
+++ b/numhask.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               numhask
-version:            0.9.0.0
+version:            0.10.0.0
 synopsis:           A numeric class hierarchy.
 description:
   This package provides alternative numeric classes over Prelude.
@@ -35,13 +35,14 @@ source-repository head
   subdir:   numhask
 
 library
-  hs-source-dirs:   src
+  hs-source-dirs:           src
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -fwrite-ide-info
     -hiedir=.hie
+
   x-docspec-extra-packages: QuickCheck
-  build-depends:    base >=4.7 && <5
+  build-depends:            base >=4.7 && <5
   exposed-modules:
     NumHask
     NumHask.Algebra.Additive
@@ -59,11 +60,13 @@ library
     NumHask.Prelude
 
   other-modules:
-  default-language: Haskell2010
+  default-language:         Haskell2010
 
 test-suite doctests
-    type:             exitcode-stdio-1.0
-    main-is:          doctests.hs
-    hs-source-dirs:   test
-    default-language: Haskell2010
-    build-depends:    base, QuickCheck
+  type:             exitcode-stdio-1.0
+  main-is:          doctests.hs
+  hs-source-dirs:   test
+  default-language: Haskell2010
+  build-depends:
+    , base
+    , QuickCheck

--- a/numhask.cabal
+++ b/numhask.cabal
@@ -40,7 +40,7 @@ library
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -fwrite-ide-info
     -hiedir=.hie
-
+  x-docspec-extra-packages: QuickCheck
   build-depends:    base >=4.7 && <5
   exposed-modules:
     NumHask
@@ -60,3 +60,10 @@ library
 
   other-modules:
   default-language: Haskell2010
+
+test-suite doctests
+    type:             exitcode-stdio-1.0
+    main-is:          doctests.hs
+    hs-source-dirs:   test
+    default-language: Haskell2010
+    build-depends:    base, QuickCheck

--- a/src/NumHask.hs
+++ b/src/NumHask.hs
@@ -20,28 +20,27 @@ module NumHask
     -- * Additive
     Additive (..),
     sum,
+    accsum,
     Subtractive (..),
-    (-),
 
     -- * Multiplicative
     Multiplicative (..),
     product,
+    accproduct,
     Divisive (..),
-    (/),
 
     -- * Ring
-    module NumHask.Algebra.Ring,
+    Distributive,
+    Ring,
+    StarSemiring (..),
+    KleeneAlgebra,
+    InvolutiveRing (..),
+    two,
 
     -- * Field
     ExpField (..),
-    logBase,
-    sqrt,
     Field,
     QuotientField (..),
-    round,
-    ceiling,
-    floor,
-    truncate,
     TrigField (..),
     infinity,
     negInfinity,
@@ -49,49 +48,82 @@ module NumHask
     half,
 
     -- * Lattice
-    module NumHask.Algebra.Lattice,
+    JoinSemiLattice (..),
+    joinLeq,
+    (<\),
+    MeetSemiLattice (..),
+    meetLeq,
+    (</),
+    BoundedJoinSemiLattice (..),
+    BoundedMeetSemiLattice (..),
 
     -- * Module
-    module NumHask.Algebra.Module,
+    AdditiveAction (..),
+    (+.),
+    SubtractiveAction (..),
+    (-.),
+    MultiplicativeAction (..),
+    (*.),
+    DivisiveAction (..),
+    (/.),
+    Module,
 
     -- * Metric
-    module NumHask.Algebra.Metric,
+    Signed (..),
+    Norm (..),
+    distance,
+    Direction (..),
+    Polar (..),
+    polar,
+    coord,
+    Epsilon (..),
+    (~=),
 
     -- * Complex
-    module NumHask.Data.Complex,
+    Complex (..),
+    realPart,
+    imagPart,
 
     -- * Integral
-    module NumHask.Data.Integral,
+    Integral (..),
+    ToIntegral (..),
+    FromIntegral (..),
+    FromInteger (..),
+    even,
+    odd,
+    (^^),
+    (^),
 
     -- * Rational
-    module NumHask.Data.Rational,
+    Ratio (..),
+    Rational,
+    ToRatio (..),
+    FromRatio (..),
+    FromRational (..),
+    reduce,
+    gcd,
 
     -- * Exceptions
-    module NumHask.Exception,
+    NumHaskException (..),
+    throw,
   )
 where
 
 import NumHask.Algebra.Additive
   ( Additive (..),
     Subtractive (..),
+    accsum,
     sum,
-    (-),
   )
 import NumHask.Algebra.Field
   ( ExpField (..),
     Field,
     QuotientField (..),
     TrigField (..),
-    ceiling,
-    floor,
     half,
     infinity,
-    logBase,
     nan,
     negInfinity,
-    round,
-    sqrt,
-    truncate,
   )
 import NumHask.Algebra.Lattice
   ( BoundedJoinSemiLattice (..),
@@ -100,6 +132,8 @@ import NumHask.Algebra.Lattice
     MeetSemiLattice (..),
     joinLeq,
     meetLeq,
+    (</),
+    (<\),
   )
 import NumHask.Algebra.Metric
   ( Direction (..),
@@ -107,8 +141,10 @@ import NumHask.Algebra.Metric
     Norm (..),
     Polar (..),
     Signed (..),
+    aboutEqual,
     coord,
     distance,
+    nearZero,
     polar,
     (~=),
   )
@@ -126,8 +162,8 @@ import NumHask.Algebra.Module
 import NumHask.Algebra.Multiplicative
   ( Divisive (..),
     Multiplicative (..),
+    accproduct,
     product,
-    (/),
   )
 import NumHask.Algebra.Ring
   ( Distributive,

--- a/src/NumHask.hs
+++ b/src/NumHask.hs
@@ -38,8 +38,8 @@ module NumHask
     two,
 
     -- * Field
-    ExpField (..),
     Field,
+    ExpField (..),
     QuotientField (..),
     TrigField (..),
     infinity,

--- a/src/NumHask/Algebra/Additive.hs
+++ b/src/NumHask/Algebra/Additive.hs
@@ -22,7 +22,6 @@ import qualified Prelude as P
 -- $setup
 --
 -- >>> :set -XRebindableSyntax
--- >>> :set -XFlexibleContexts
 -- >>> import NumHask.Prelude
 
 -- | or [Addition](https://en.wikipedia.org/wiki/Addition)
@@ -30,9 +29,9 @@ import qualified Prelude as P
 -- For practical reasons, we begin the class tree with 'NumHask.Algebra.Additive.Additive'.  Starting with  'NumHask.Algebra.Group.Associative' and 'NumHask.Algebra.Group.Unital', or using 'Data.Semigroup.Semigroup' and 'Data.Monoid.Monoid' from base tends to confuse the interface once you start having to disinguish between (say) monoidal addition and monoidal multiplication.
 --
 -- prop> \a -> zero + a == a
--- > \a -> a + zero == a
--- > \a b c -> (a + b) + c == a + (b + c)
--- > \a b -> a + b == b + a
+-- prop> \a -> a + zero == a
+-- prop> \a b c -> (a + b) + c == a + (b + c)
+-- prop> \a b -> a + b == b + a
 --
 -- By convention, (+) is regarded as commutative, but this is not universal, and the introduction of another symbol which means non-commutative addition seems a bit dogmatic.
 --
@@ -48,19 +47,25 @@ class Additive a where
   zero :: a
 
 -- | Compute the sum of a 'Data.Foldable.Foldable'.
+--
+-- >>> sum [0..10]
+-- 55
 sum :: (Additive a, P.Foldable f) => f a -> a
 sum = foldl' (+) zero
 
 -- | Compute the accumulating sum of a 'Data.Traversable.Traversable'.
+--
+-- >>> accsum [0..10]
+-- [0,1,3,6,10,15,21,28,36,45,55]
 accsum :: (Additive a, P.Traversable f) => f a -> f a
 accsum = P.snd P.. mapAccumL (\a b -> (a + b, a + b)) zero
 
 -- | or [Subtraction](https://en.wikipedia.org/wiki/Subtraction)
 --
--- > \a -> a - a == zero
--- > \a -> negate a == zero - a
--- > \a -> negate a + a == zero
--- > \a -> a + negate a == zero
+-- prop> \a -> a - a == zero
+-- prop> \a -> negate a == zero - a
+-- prop> \a -> negate a + a == zero
+-- prop> \a -> a + negate a == zero
 --
 --
 -- >>> negate 1

--- a/src/NumHask/Algebra/Additive.hs
+++ b/src/NumHask/Algebra/Additive.hs
@@ -5,15 +5,18 @@
 module NumHask.Algebra.Additive
   ( Additive (..),
     sum,
+    accsum,
     Subtractive (..),
-    (-),
   )
 where
 
+import Control.Applicative
+import Data.Foldable (foldl')
 import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Traversable (mapAccumL)
 import Data.Word (Word, Word16, Word32, Word64, Word8)
 import GHC.Natural (Natural (..))
-import Prelude (Bool, Double, Float, Int, Integer, fromInteger)
+import Prelude (Applicative, Bool, Double, Float, Functor, Int, Integer, fromInteger, ($))
 import qualified Prelude as P
 
 -- $setup
@@ -26,7 +29,7 @@ import qualified Prelude as P
 --
 -- For practical reasons, we begin the class tree with 'NumHask.Algebra.Additive.Additive'.  Starting with  'NumHask.Algebra.Group.Associative' and 'NumHask.Algebra.Group.Unital', or using 'Data.Semigroup.Semigroup' and 'Data.Monoid.Monoid' from base tends to confuse the interface once you start having to disinguish between (say) monoidal addition and monoidal multiplication.
 --
--- > \a -> zero + a == a
+-- prop> \a -> zero + a == a
 -- > \a -> a + zero == a
 -- > \a b c -> (a + b) + c == a + (b + c)
 -- > \a b -> a + b == b + a
@@ -46,7 +49,11 @@ class Additive a where
 
 -- | Compute the sum of a 'Data.Foldable.Foldable'.
 sum :: (Additive a, P.Foldable f) => f a -> a
-sum = P.foldr (+) zero
+sum = foldl' (+) zero
+
+-- | Compute the accumulating sum of a 'Data.Traversable.Traversable'.
+accsum :: (Additive a, P.Traversable f) => f a -> f a
+accsum = P.snd P.. mapAccumL (\a b -> (a + b, a + b)) zero
 
 -- | or [Subtraction](https://en.wikipedia.org/wiki/Subtraction)
 --
@@ -58,17 +65,16 @@ sum = P.foldr (+) zero
 --
 -- >>> negate 1
 -- -1
-class (Additive a) => Subtractive a where
-  negate :: a -> a
-
-infixl 6 -
-
--- | minus
 --
 -- >>> 1 - 2
 -- -1
-(-) :: (Subtractive a) => a -> a -> a
-(-) a b = a + negate b
+class (Additive a) => Subtractive a where
+  negate :: a -> a
+  negate a = zero - a
+
+  infixl 6 -
+  (-) :: a -> a -> a
+  a - b = a + negate b
 
 instance Additive Double where
   (+) = (P.+)

--- a/src/NumHask/Algebra/Field.hs
+++ b/src/NumHask/Algebra/Field.hs
@@ -34,14 +34,13 @@ import qualified Prelude as P
 -- $setup
 --
 -- >>> :set -XRebindableSyntax
--- >>> :set -XFlexibleContexts
 -- >>> :set -XScopedTypeVariables
 -- >>> import NumHask.Prelude
 
 -- | A <https://en.wikipedia.org/wiki/Field_(mathematics) Field> is a set
 --   on which addition, subtraction, multiplication, and division are defined. It is also assumed that multiplication is distributive over addition.
 --
--- A summary of the rules inherited from super-classes of Field. Floating point computation is a terrible, messy business and, in practice, only rough approximation can be achieve for association and distribution.
+-- A summary of the rules inherited from super-classes of Field:
 --
 -- > zero + a == a
 -- > a + zero == a
@@ -74,9 +73,9 @@ instance Field b => Field (a -> b)
 
 -- | A hyperbolic field class
 --
--- > sqrt . (**2) == id
--- > log . exp == id
--- > for +ive b, a != 0,1: a ** logBase a b ≈ b
+-- prop> \a -> a < zero || (sqrt . (**2)) a == a
+-- prop> \a -> a < zero || (log . exp) a ~= a
+-- prop> \a b -> (b < zero) || a <= zero || a == 1 || abs (a ** logBase a b - b) < 10 * epsilon
 class
   (Field a) =>
   ExpField a
@@ -118,8 +117,9 @@ instance ExpField b => ExpField (a -> b) where
 --
 -- See [Field of fractions](https://en.wikipedia.org/wiki/Field_of_fractions)
 --
--- > a - one < floor a <= a <= ceiling a < a + one
--- > round a == floor (a + half)
+-- > \a -> a - one < floor a <= a <= ceiling a < a + one
+-- prop> (\a -> a - one < fromIntegral (floor a :: Int) && fromIntegral (floor a :: Int) <= a && a <= fromIntegral (ceiling a :: Int) && fromIntegral (ceiling a :: Int) <= a + one) :: Double -> Bool
+-- prop> \a -> (round a :: Int) ~= (floor (a + half) :: Int)
 class (Field a, Multiplicative b, Additive b) => QuotientField a b where
   properFraction :: a -> (b, a)
 
@@ -225,6 +225,8 @@ negInfinity :: (Field a) => a
 negInfinity = negate infinity
 
 -- | Trigonometric Field
+--
+-- The list of laws is quite long: <https://en.wikipedia.org/wiki/List_of_trigonometric_identities trigonometric identities>
 class
   (Field a) =>
   TrigField a
@@ -289,5 +291,8 @@ instance TrigField b => TrigField (a -> b) where
   atanh f = atanh . f
 
 -- | A 'half' is a 'Field' because it requires addition, multiplication and division.
+--
+-- >>> half :: Double
+-- 0.5
 half :: (Field a) => a
 half = one / two

--- a/src/NumHask/Algebra/Lattice.hs
+++ b/src/NumHask/Algebra/Lattice.hs
@@ -8,8 +8,10 @@
 module NumHask.Algebra.Lattice
   ( JoinSemiLattice (..),
     joinLeq,
+    (<\),
     MeetSemiLattice (..),
     meetLeq,
+    (</),
     BoundedJoinSemiLattice (..),
     BoundedMeetSemiLattice (..),
   )
@@ -46,6 +48,12 @@ class (Eq a) => JoinSemiLattice a where
 joinLeq :: (JoinSemiLattice a) => a -> a -> Bool
 joinLeq x y = (x \/ y) == y
 
+infixr 6 <\
+
+-- | The partial ordering induced by the join-semilattice structure
+(<\) :: (JoinSemiLattice a) => a -> a -> Bool
+(<\) = joinLeq
+
 -- | A algebraic structure with element meets: See [Semilattice](http://en.wikipedia.org/wiki/Semilattice)
 --
 -- > Associativity: x /\ (y /\ z) == (x /\ y) /\ z
@@ -58,6 +66,12 @@ class (Eq a) => MeetSemiLattice a where
 -- | The partial ordering induced by the meet-semilattice structure
 meetLeq :: (MeetSemiLattice a) => a -> a -> Bool
 meetLeq x y = (x /\ y) == x
+
+infixr 6 </
+
+-- | The partial ordering induced by the meet-semilattice structure
+(</) :: (MeetSemiLattice a) => a -> a -> Bool
+(</) = meetLeq
 
 -- | The combination of two semi lattices makes a lattice if the absorption law holds:
 -- see [Absorption Law](http://en.wikipedia.org/wiki/Absorption_law) and [Lattice](http://en.wikipedia.org/wiki/Lattice_(order\))

--- a/src/NumHask/Algebra/Metric.hs
+++ b/src/NumHask/Algebra/Metric.hs
@@ -43,11 +43,18 @@ import qualified Prelude as P
 
 -- | 'signum' from base is not an operator name in numhask and is replaced by 'sign'.  Compare with 'Norm' where there is a change in codomain.
 --
--- >> abs a * sign a == a
+-- prop> \a -> abs a * sign a ~= a
 --
 -- abs zero == zero, so any value for sign zero is ok.  We choose lawful neutral:
 --
--- > sign zero == zero
+-- >>> sign zero == zero
+-- True
+--
+-- >>> abs (-1)
+-- 1
+--
+-- >>> sign (-1)
+-- -1
 class
   (Additive a, Multiplicative a) =>
   Signed a
@@ -149,10 +156,16 @@ instance Signed Word64 where
 
 -- | Norm is a slight generalisation of Signed. The class has the same shape but allows the codomain to be different to the domain.
 --
--- > norm a >= zero
--- > norm zero == zero
--- > a == norm a .* basis a
--- > norm (basis a) == one
+-- > \a -> norm a >= zero
+-- > \a -> norm zero == zero
+-- > \a -> a == norm a .* basis a
+-- > \a -> norm (basis a) == one
+--
+-- >>> norm (-0.5 :: Double) :: Double
+-- 0.5
+--
+-- >>> basis (-0.5 :: Double) :: Double
+-- -1.0
 class (Additive a, Multiplicative b, Additive b) => Norm a b | a -> b where
   -- | or length, or ||v||
   norm :: a -> b

--- a/src/NumHask/Algebra/Multiplicative.hs
+++ b/src/NumHask/Algebra/Multiplicative.hs
@@ -20,8 +20,6 @@ import qualified Prelude as P
 -- $setup
 --
 -- >>> :set -XRebindableSyntax
--- >>> :set -XFlexibleContexts
--- >>> :set -XScopedTypeVariables
 -- >>> import NumHask.Prelude
 
 -- | or [Multiplication](https://en.wikipedia.org/wiki/Multiplication)
@@ -29,9 +27,9 @@ import qualified Prelude as P
 -- For practical reasons, we begin the class tree with 'NumHask.Algebra.Additive.Additive' and 'Multiplicative'.  Starting with  'NumHask.Algebra.Group.Associative' and 'NumHask.Algebra.Group.Unital', or using 'Data.Semigroup.Semigroup' and 'Data.Monoid.Monoid' from base tends to confuse the interface once you start having to disinguish between (say) monoidal addition and monoidal multiplication.
 --
 --
--- > \a -> one * a == a
--- > \a -> a * one == a
--- > \a b c -> (a * b) * c == a * (b * c)
+-- prop> \a -> one * a == a
+-- prop> \a -> a * one == a
+-- prop> \a b c -> (a * b) * c == a * (b * c)
 --
 -- By convention, (*) is regarded as not necessarily commutative, but this is not universal, and the introduction of another symbol which means commutative multiplication seems a bit dogmatic.
 --
@@ -47,10 +45,16 @@ class Multiplicative a where
   one :: a
 
 -- | Compute the product of a 'Data.Foldable.Foldable'.
+--
+-- >>> product [1..5]
+-- 120
 product :: (Multiplicative a, P.Foldable f) => f a -> a
 product = P.foldr (*) one
 
 -- | Compute the accumulating product of a 'Data.Traversable.Traversable'.
+--
+-- >>> accproduct [1..5]
+-- [1,2,6,24,120]
 accproduct :: (Multiplicative a, P.Traversable f) => f a -> f a
 accproduct = P.snd P.. mapAccumL (\a b -> (a * b, a * b)) one
 
@@ -58,10 +62,10 @@ accproduct = P.snd P.. mapAccumL (\a b -> (a * b, a * b)) one
 --
 -- Though unusual, the term Divisive usefully fits in with the grammer of other classes and avoids name clashes that occur with some popular libraries.
 --
--- > \(a :: Double) -> a / a ~= one || a == zero
--- > \(a :: Double) -> recip a ~= one / a || a == zero
--- > \(a :: Double) -> recip a * a ~= one || a == zero
--- > \(a :: Double) -> a * recip a ~= one || a == zero
+-- prop> \(a :: Double) -> a / a ~= one || a == zero
+-- prop> \(a :: Double) -> recip a ~= one / a || a == zero
+-- prop> \(a :: Double) -> recip a * a ~= one || a == zero
+-- prop> \(a :: Double) -> a * recip a ~= one || a == zero
 --
 -- >>> recip 2.0
 -- 0.5

--- a/src/NumHask/Algebra/Multiplicative.hs
+++ b/src/NumHask/Algebra/Multiplicative.hs
@@ -5,12 +5,13 @@
 module NumHask.Algebra.Multiplicative
   ( Multiplicative (..),
     product,
+    accproduct,
     Divisive (..),
-    (/),
   )
 where
 
 import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Traversable (mapAccumL)
 import Data.Word (Word, Word16, Word32, Word64, Word8)
 import GHC.Natural (Natural (..))
 import Prelude (Double, Float, Int, Integer, fromInteger, fromRational)
@@ -49,6 +50,10 @@ class Multiplicative a where
 product :: (Multiplicative a, P.Foldable f) => f a -> a
 product = P.foldr (*) one
 
+-- | Compute the accumulating product of a 'Data.Traversable.Traversable'.
+accproduct :: (Multiplicative a, P.Traversable f) => f a -> f a
+accproduct = P.snd P.. mapAccumL (\a b -> (a * b, a * b)) one
+
 -- | or [Division](https://en.wikipedia.org/wiki/Division_(mathematics\))
 --
 -- Though unusual, the term Divisive usefully fits in with the grammer of other classes and avoids name clashes that occur with some popular libraries.
@@ -60,17 +65,17 @@ product = P.foldr (*) one
 --
 -- >>> recip 2.0
 -- 0.5
-class (Multiplicative a) => Divisive a where
-  recip :: a -> a
-
-infixl 7 /
-
--- | divide
 --
 -- >>> 1 / 2
 -- 0.5
-(/) :: (Divisive a) => a -> a -> a
-(/) a b = a * recip b
+class (Multiplicative a) => Divisive a where
+  recip :: a -> a
+  recip a = one / a
+
+  infixl 7 /
+
+  (/) :: a -> a -> a
+  (/) a b = a * recip b
 
 instance Multiplicative Double where
   (*) = (P.*)

--- a/src/NumHask/Algebra/Ring.hs
+++ b/src/NumHask/Algebra/Ring.hs
@@ -24,16 +24,14 @@ import qualified Prelude as P
 -- $setup
 --
 -- >>> :set -XRebindableSyntax
--- >>> :set -XFlexibleContexts
--- >>> :set -XScopedTypeVariables
 -- >>> import NumHask.Prelude
 
 -- | <https://en.wikipedia.org/wiki/Distributive_property Distributive>
 --
--- > \a b c -> a * (b + c) == a * b + a * c
--- > \a b c -> (a + b) * c == a * c + b * c
--- > \a -> zero * a == zero
--- > \a -> a * zero == zero
+-- prop> \a b c -> a * (b + c) == a * b + a * c
+-- prop> \a b c -> (a + b) * c == a * c + b * c
+-- prop> \a -> zero * a == zero
+-- prop> \a -> a * zero == zero
 --
 -- The sneaking in of the <https://en.wikipedia.org/wiki/Absorbing_element Absorption> laws here glosses over the possibility that the multiplicative zero element does not have to correspond with the additive unital zero.
 class
@@ -99,7 +97,7 @@ instance
 
 -- | A <https://en.wikipedia.org/wiki/Semiring#Star_semirings StarSemiring> is a semiring with an additional unary operator (star) satisfying:
 --
--- > \a -> star a = one + a * star a
+-- > \a -> star a == one + a * star a
 class (Distributive a) => StarSemiring a where
   star :: a -> a
   star a = one + plus a

--- a/src/NumHask/Data/Complex.hs
+++ b/src/NumHask/Data/Complex.hs
@@ -117,10 +117,12 @@ instance (TrigField a) => Direction (Complex a) a where
   ray x = cos x :+ sin x
 
 instance
-  (Ord a, Signed a, Subtractive a, Epsilon a) =>
+  (Ord a, Signed a, Epsilon a, Subtractive a) =>
   Epsilon (Complex a)
   where
   epsilon = epsilon :+ epsilon
+
+  nearZero (ar :+ ai) = ar <= epsilon && ai <= epsilon
 
 instance (Field a) => Field (Complex a)
 

--- a/src/NumHask/Data/Integral.hs
+++ b/src/NumHask/Data/Integral.hs
@@ -30,9 +30,23 @@ import NumHask.Algebra.Ring
 import Prelude (Double, Float, Int, Integer, fst, snd, (.))
 import qualified Prelude as P
 
+-- $setup
+--
+-- >>> :set -XRebindableSyntax
+-- >>> import NumHask.Prelude
+
 -- | An Integral is anything that satisfies the law:
 --
--- > b == zero || b * (a `div` b) + (a `mod` b) == a
+-- prop> \a b -> b == zero || b * (a `div` b) + (a `mod` b) == a
+--
+-- >>> 3 `divMod` 2
+-- (1,1)
+--
+-- >>> (-3) `divMod` 2
+-- (-2,1)
+--
+-- >>> (-3) `quotRem` 2
+-- (-1,-1)
 class
   (Distributive a) =>
   Integral a
@@ -414,6 +428,12 @@ odd = P.not . even
 infixr 8 ^^
 
 -- | raise a number to an 'Integral' power
+--
+-- >>> 2 ^^ 3
+-- 8.0
+--
+-- >>> 2 ^^ (-2)
+-- 0.25
 (^^) ::
   (P.Ord b, Divisive a, Subtractive b, Integral b) =>
   a ->
@@ -439,6 +459,12 @@ infixr 8 ^
 -- | raise a number to an 'Int' power
 --
 -- Note: This differs from (^) found in prelude which is a partial function (it errors on negative integrals). This monomorphic version is provided to help reduce ambiguous type noise in common usages of this sign.
+--
+-- >>> 2 ^ 3
+-- 8.0
+--
+-- >>> 2 ^ (-2)
+-- 0.25
 (^) ::
   (Divisive a) => a -> Int -> a
 (^) x n = x ^^ n

--- a/src/NumHask/Data/Rational.hs
+++ b/src/NumHask/Data/Rational.hs
@@ -91,7 +91,7 @@ instance (P.Ord a, Signed a, Integral a, Ring a) => Distributive (Ratio a)
 
 instance (P.Ord a, Signed a, Integral a, Ring a) => Field (Ratio a)
 
-instance (P.Ord a, Signed a, Integral a, Ring a, Signed b, FromIntegral b a) => QuotientField (Ratio a) b where
+instance (P.Ord a, P.Ord b, Signed a, Integral a, Ring a, Signed b, Subtractive b, Integral b, FromIntegral b a) => QuotientField (Ratio a) b where
   properFraction (n :% d) = let (w, r) = quotRem n d in (fromIntegral w, r :% d)
 
 instance (P.Ord a, Signed a, Integral a, Ring a) => Signed (Ratio a) where

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -1,0 +1,8 @@
+module Main where
+
+main :: IO ()
+main = do
+    putStrLn "This test-suite exists only to add dependencies"
+    putStrLn "To run doctests: "
+    putStrLn "    cabal build all --enable-tests"
+    putStrLn "    cabal-docspec"

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -2,7 +2,7 @@ module Main where
 
 main :: IO ()
 main = do
-    putStrLn "This test-suite exists only to add dependencies"
-    putStrLn "To run doctests: "
-    putStrLn "    cabal build all --enable-tests"
-    putStrLn "    cabal-docspec"
+  putStrLn "This test-suite exists only to add dependencies"
+  putStrLn "To run doctests: "
+  putStrLn "    cabal build all --enable-tests"
+  putStrLn "    cabal-docspec"


### PR DESCRIPTION
- Reversal of operators being shoved outside of class definitions, except for (*.) (/.) (+.) & (-.).
- Doctests added
- properties turned on