### PR TITLE
fix: ormolu, hlint, and docspec errors in Patterns.hs

### DIFF
--- a/src/NumHask.hs
+++ b/src/NumHask.hs
@@ -130,11 +130,11 @@ import NumHask.Algebra.Action
     Module,
     MultiplicativeAction (..),
     SubtractiveAction (..),
+    TrivialAction (..),
     (*|),
     (+|),
     (-|),
     (/|),
-    TrivialAction (..),
   )
 import NumHask.Algebra.Additive
   ( Additive (..),
@@ -199,9 +199,9 @@ import NumHask.Algebra.Ring
 import NumHask.Data.Complex
   ( Complex (..),
     imagPart,
+    normSquared,
     realPart,
     (+:),
-    normSquared,
   )
 import NumHask.Data.Integral
   ( FromInt,
@@ -221,10 +221,10 @@ import NumHask.Data.Rational
     Ratio (..),
     Rational,
     ToRatio (..),
-    gcd,
-    reduce,
-    numerator,
     denominator,
+    gcd,
+    numerator,
+    reduce,
   )
 import NumHask.Exception (NumHaskException (..), throw)
 

--- a/src/NumHask/Algebra/Action.hs
+++ b/src/NumHask/Algebra/Action.hs
@@ -18,10 +18,10 @@ module NumHask.Algebra.Action
 where
 
 import Data.Kind (Type)
-import NumHask.Algebra.Additive (Additive(..), Subtractive(..))
-import NumHask.Algebra.Multiplicative (Divisive(..), Multiplicative(..))
+import NumHask.Algebra.Additive (Additive (..), Subtractive (..))
+import NumHask.Algebra.Multiplicative (Divisive (..), Multiplicative (..))
 import NumHask.Algebra.Ring (Distributive)
-import Prelude (flip, Eq, Ord)
+import Prelude (Eq, Ord, flip)
 
 -- | Additive Action
 --
@@ -113,20 +113,21 @@ a /| b = a *| recip b
 type Module m = (Distributive (Scalar m), MultiplicativeAction m)
 
 -- | An action of a set of numbers on itself
-newtype TrivialAction a = TrivialAction {
-  getTrivialAction :: a
-} deriving (Eq, Ord, Additive, Subtractive, Multiplicative, Divisive)
+newtype TrivialAction a = TrivialAction
+  { getTrivialAction :: a
+  }
+  deriving (Eq, Ord, Additive, Subtractive, Multiplicative, Divisive)
 
-instance Additive a => AdditiveAction (TrivialAction a) where
+instance (Additive a) => AdditiveAction (TrivialAction a) where
   type AdditiveScalar (TrivialAction a) = a
   TrivialAction a |+ b = TrivialAction (a + b)
 
-instance Subtractive a => SubtractiveAction (TrivialAction a) where
+instance (Subtractive a) => SubtractiveAction (TrivialAction a) where
   TrivialAction a |- b = TrivialAction (a - b)
 
-instance Multiplicative a => MultiplicativeAction (TrivialAction a) where
+instance (Multiplicative a) => MultiplicativeAction (TrivialAction a) where
   type Scalar (TrivialAction a) = a
   TrivialAction a |* b = TrivialAction (a * b)
 
-instance Divisive a => DivisiveAction (TrivialAction a) where
+instance (Divisive a) => DivisiveAction (TrivialAction a) where
   TrivialAction a |/ b = TrivialAction (a / b)

--- a/src/NumHask/Algebra/Patterns.hs
+++ b/src/NumHask/Algebra/Patterns.hs
@@ -3,8 +3,7 @@
 
 -- | Patterns for common tests
 module NumHask.Algebra.Patterns
-  (
-    pattern Zero,
+  ( pattern Zero,
     pattern One,
     pattern MinusOne,
   )
@@ -12,28 +11,26 @@ where
 
 import NumHask.Algebra.Additive
 import NumHask.Algebra.Multiplicative
-import Prelude (Bool(..), Eq(..), (.))
+import Prelude (Bool (..), Eq (..), (.))
 
 -- | Enabling pattern matching on zero:
 --
--- >>> isItZero Zero = True
--- >>> isItZero _    = False
+-- > isItZero Zero = True
+-- > isItZero _    = False
 pattern Zero :: forall a. (Eq a, Additive a) => a
 pattern Zero <- ((== zero) -> True)
 
-
 -- | Enabling pattern matching on one:
 --
--- >>> isItOne One = True
--- >>> isItOne _   = False
+-- > isItOne One = True
+-- > isItOne _   = False
 pattern One :: forall a. (Eq a, Multiplicative a) => a
 pattern One <- ((== one) -> True)
 
-
 -- | Enabling pattern matching on minus one:
 --
--- >>> isItMinusOne MinusOne = True
--- >>> isItMinusOne _        = False
+-- > isItMinusOne MinusOne = True
+-- > isItMinusOne _        = False
 --
 -- The means of testing (that is, add one, and check if it equals
 -- zero) might be surprising. Other, more obvious, methods would
@@ -43,4 +40,4 @@ pattern One <- ((== one) -> True)
 -- one, but that would fail on any 'Natural' whatsoever, since 'negate
 -- one' underflows.)
 pattern MinusOne :: forall a. (Eq a, Additive a, Multiplicative a) => a
-pattern MinusOne <- (((== zero) . (+ one)) -> True)
+pattern MinusOne <- ((== zero) . (+ one) -> True)

--- a/src/NumHask/Data/Complex.hs
+++ b/src/NumHask/Data/Complex.hs
@@ -135,5 +135,5 @@ instance (Subtractive a, QuotientField a) => QuotientField (Complex a) where
 
 -- | The squared norm: frequently useful, and doesn't require the
 -- ability to take square roots.
-normSquared :: Distributive a => Complex a -> a
-normSquared (Complex (x, y)) = x*x + y*y
+normSquared :: (Distributive a) => Complex a -> a
+normSquared (Complex (x, y)) = x * x + y * y

--- a/src/NumHask/Data/Integral.hs
+++ b/src/NumHask/Data/Integral.hs
@@ -421,9 +421,9 @@ instance FromInteger Word32 where
 instance FromInteger Word64 where
   fromInteger = P.fromInteger
 
-deriving instance FromInteger a => FromInteger (Sum a)
+deriving instance (FromInteger a) => FromInteger (Sum a)
 
-deriving instance FromInteger a => FromInteger (Product a)
+deriving instance (FromInteger a) => FromInteger (Product a)
 
 infixr 8 ^^
 

--- a/src/NumHask/Data/Positive.hs
+++ b/src/NumHask/Data/Positive.hs
@@ -18,7 +18,6 @@ where
 import Control.Category ((>>>))
 import Data.Bool (bool)
 import Data.Maybe
-import Numeric.Natural (Natural, minusNaturalMaybe)
 import NumHask.Algebra.Action
 import NumHask.Algebra.Additive
 import NumHask.Algebra.Field
@@ -29,6 +28,7 @@ import NumHask.Algebra.Ring
 import NumHask.Data.Integral
 import NumHask.Data.Rational
 import NumHask.Data.Wrapped
+import Numeric.Natural (Natural, minusNaturalMaybe)
 import Prelude (Eq, Ord, Show)
 import Prelude qualified as P
 
@@ -172,7 +172,7 @@ newtype MonusFromOrd a = MonusFromOrd a
 
 instance (Ord a, Subtractive a) => Monus (MonusFromOrd a) where
   x ∸ y
-    | x P.< y     = zero
+    | x P.< y = zero
     | P.otherwise = x - y
 
 -- | It appears that Haskell doesn't have any built in truncated


### PR DESCRIPTION
## What

- Changed 3 `>>>` doctests to `>` (non-executable code blocks) — they use undefined functions (`isItZero`, etc.) and aren't executable tests
- Removed redundant bracket caught by hlint  
- `RebindableSyntax` + GHC 9.14 was stricter about `True`/`False` in the cabal-docspec context

## Verification

```
ormolu: ok
hlint: no hints
cabal build all: ok
cabal-docspec: 0 errors
```